### PR TITLE
ReferNotifier sendRequest ignored

### DIFF
--- a/lib/RTCSession/ReferNotifier.js
+++ b/lib/RTCSession/ReferNotifier.js
@@ -44,18 +44,23 @@ module.exports = class ReferNotifier
       state = `active;expires=${this._expires}`;
     }
 
-    // Put this in a try/catch block.
-    this._session.sendRequest(JsSIP_C.NOTIFY, {
-      extraHeaders : [
-        `Event: ${C.event_type};id=${this._id}`,
-        `Subscription-State: ${state}`,
-        `Content-Type: ${C.body_type}`
-      ],
-      body          : `SIP/2.0 ${code} ${reason}`,
-      eventHandlers : {
-        // If a negative response is received, subscription is canceled.
-        onErrorResponse() { this._active = false; }
-      }
-    });
+    try
+    {
+      this._session.sendRequest(JsSIP_C.NOTIFY, {
+        extraHeaders : [
+          `Event: ${C.event_type};id=${this._id}`,
+          `Subscription-State: ${state}`,
+          `Content-Type: ${C.body_type}`
+        ],
+        body          : `SIP/2.0 ${code} ${reason}`,
+        eventHandlers : {
+          // If a negative response is received, subscription is canceled.
+          onErrorResponse() { this._active = false; }
+        }
+      });
+    }
+    catch (e) {
+      logger.debug('sendRequest exception ignored', e);
+    }
   }
 };


### PR DESCRIPTION
Scenario to be solved:
A is on communication with B
B transfers the call to C (blind transfer)
B hangups the call with A, when trying is received C answers the call and the exception is triggered, killing the call

The exception is triggered whenever A is trying to notify B about the refer status.

Resolves:
VOICIS-7971